### PR TITLE
npm: chnage npm start to node-static

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "webpack:dev": "webpack --progress",
     "webpack:prod": "cross-env NODE_ENV=production webpack -p --progress",
     "prestart": "npm run webpack:prod",
-    "start": "http-server",
+    "start": "cross-env NODE_ENV=production static public",
     "dev": "webpack --watch --progress",
     "lint": "eslint src"
   },
@@ -35,5 +35,8 @@
     "style-loader": "0.18.2",
     "url-loader": "0.5.9",
     "webpack": "3.0.0"
+  },
+  "peerDependencies": {
+    "node-static": "*"
   }
 }


### PR DESCRIPTION
Because `http-server` exposes folder directories structure to the public.
I don't want visitors to see them appear here.

Replace `http-server` with `node-static` that serves the purposes, but hide the folder structure away.
